### PR TITLE
Fix negative countdown timer bug

### DIFF
--- a/src/features/HexClock.tsx
+++ b/src/features/HexClock.tsx
@@ -31,7 +31,7 @@ export const HexClock = () => {
     const updateBlockTime = async () => {
         try {
             const block = await provider.getBlock('latest');
-            const newBlockTime = DateTime.fromMillis(block.timestamp * 1000);
+            const newBlockTime = DateTime.fromMillis(block.timestamp * 1000, { zone: 'utc' });
             setBlockTime(newBlockTime);
             setCountDownTimerString(timeTillMidnightUTC(newBlockTime).toFormat('hh\'h\':mm\'m\''));
             setHexDay(dateToHexDay(newBlockTime));


### PR DESCRIPTION
Without specifying `{ zone: 'utc' }`, the `DateTime` object defaults to local time. Result: just after the day ticks over, the code then uses the previous midnight instead of the next midnight for what to count down to.